### PR TITLE
Feature/fe 22 section page runtime refactor pure ssg

### DIFF
--- a/frontend/src/app/(dashboard)/courses/[slug]/sections/[section_id_str]/page.tsx
+++ b/frontend/src/app/(dashboard)/courses/[slug]/sections/[section_id_str]/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from "next/navigation";
 import { MDXRemote } from "next-mdx-remote/rsc";
 
 import { getAllSectionParams, getSectionContent } from "@/lib/content";
-import { getCourseBySlug } from "@/lib/fetchCourses";
 import { SectionActions } from "@/components/features/courses/section-actions";
 
 // ---------------------------------------------------------------------------
@@ -90,12 +89,9 @@ interface PageProps {
 
 export default async function SectionPage({ params }: PageProps) {
   const { slug, section_id_str } = await params;
-  const [data, course] = await Promise.all([
-    getSectionContent(slug, section_id_str),
-    getCourseBySlug(slug),
-  ]);
+  const data = getSectionContent(slug, section_id_str);
 
-  if (!data || !course) notFound();
+  if (!data) notFound();
 
   const { frontmatter, content, allSections, prevSection, nextSection } = data;
 
@@ -103,7 +99,6 @@ export default async function SectionPage({ params }: PageProps) {
     <div className="flex h-full bg-zinc-50 dark:bg-slate-900/40 p-4 lg:p-6 gap-4 rounded-2xl">
       <SectionActions
         courseSlug={slug}
-        courseId={course.id}
         currentSectionId={section_id_str}
         sections={allSections}
         prevSection={prevSection}

--- a/frontend/src/components/features/courses/section-actions.tsx
+++ b/frontend/src/components/features/courses/section-actions.tsx
@@ -3,17 +3,17 @@
 import Link from "next/link";
 import { type AxiosError } from "axios";
 import { CheckCircle2, ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
-import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 
+import { useCourseDetail } from "@/hooks/courses/use-course-detail";
+import { useMarkSectionComplete, useSectionProgress } from "@/hooks/courses/use-section-progress";
 import type { SectionItem } from "@/lib/content";
 import { routes } from "@/lib/routes";
-import { useMarkSectionComplete, useSectionProgress } from "@/hooks/courses/use-section-progress";
+import { Skeleton } from "@/components/ui/skeleton";
 import { SectionSidebar } from "./section-sidebar";
 
 interface SectionActionsProps {
   courseSlug: string;
-  courseId: string;
   currentSectionId: string;
   sections: SectionItem[];
   prevSection: SectionItem | null;
@@ -23,36 +23,43 @@ interface SectionActionsProps {
 
 export function SectionActions({
   courseSlug,
-  courseId,
   currentSectionId,
   sections,
   prevSection,
   nextSection,
   children,
 }: SectionActionsProps) {
+  const { data: course } = useCourseDetail(courseSlug);
+  const courseId = course?.id;
+
   const { data: progressItems = [], isLoading: progressLoading } = useSectionProgress(courseId);
   const { mutate: markComplete, isPending } = useMarkSectionComplete(courseId);
 
   const completedIds = new Set(
-    progressItems.filter((p) => p.completed).map((p) => p.section_id_str),
+    progressItems.filter((progressItem) => progressItem.completed).map((item) => item.section_id_str),
   );
   const isCurrentCompleted = completedIds.has(currentSectionId);
+  const isButtonDisabled = !courseId || isCurrentCompleted || isPending;
 
   function handleMarkComplete() {
+    if (!courseId) return;
+
     markComplete(currentSectionId, {
       onSuccess: () => {
-        toast.success("Bölüm tamamlandı!", { description: "İlerlemeniz kaydedildi." });
+        toast.success("B\u00f6l\u00fcm tamamland\u0131!", {
+          description: "\u0130lerlemeniz kaydedildi.",
+        });
       },
       onError: (error: unknown) => {
         const axiosError = error as AxiosError;
-        // 401: api interceptor token refresh + logout yönetir, buraya düşmez.
+
         if (axiosError?.response?.status === 403) {
-          toast.error("Bu kursa kayıtlı değilsiniz.", {
+          toast.error("Bu kursa kay\u0131tl\u0131 de\u011filsiniz.", {
             description: "Kursa kaydolarak ilerlemenizi takip edebilirsiniz.",
           });
         } else {
-          toast.error("Bölüm kaydedilemedi.", {
-            description: "İlerlemeniz bu oturum için korundu.",
+          toast.error("B\u00f6l\u00fcm kaydedilemedi.", {
+            description: "\u0130lerlemeniz bu oturum i\u00e7in korundu.",
           });
         }
       },
@@ -64,55 +71,54 @@ export function SectionActions({
   ) : (
     <button
       onClick={handleMarkComplete}
-      disabled={isCurrentCompleted || isPending}
-      className={`w-full inline-flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl text-sm font-bold transition-all ${
+      disabled={isButtonDisabled}
+      className={`inline-flex w-full items-center justify-center gap-2 rounded-xl px-4 py-2.5 text-sm font-bold transition-all ${
         isCurrentCompleted
-          ? "bg-emerald-50 text-emerald-700 dark:bg-emerald-500/10 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-500/20 cursor-default"
-          : "bg-indigo-600 hover:bg-indigo-700 text-white shadow-lg shadow-indigo-600/20 active:scale-[0.97]"
+          ? "cursor-default border border-emerald-200 bg-emerald-50 text-emerald-700 dark:border-emerald-500/20 dark:bg-emerald-500/10 dark:text-emerald-400"
+          : isButtonDisabled
+            ? "cursor-not-allowed bg-indigo-300 text-white shadow-none dark:bg-indigo-400/40"
+            : "bg-indigo-600 text-white shadow-lg shadow-indigo-600/20 hover:bg-indigo-700 active:scale-[0.97]"
       }`}
     >
       {isPending ? (
-        <Loader2 className="w-4 h-4 animate-spin" />
+        <Loader2 className="h-4 w-4 animate-spin" />
       ) : (
-        <CheckCircle2 className="w-4 h-4" />
+        <CheckCircle2 className="h-4 w-4" />
       )}
-      {isCurrentCompleted ? "Tamamlandı" : "Tamamladım"}
+      {isCurrentCompleted ? "Tamamland\u0131" : "Tamamlad\u0131m"}
     </button>
   );
 
   return (
-    <div className="flex flex-1 min-h-0 gap-4">
-      {/* Sol kolon: article + önceki/sonraki bar — kart */}
-      <div className="flex flex-col flex-1 min-h-0 rounded-2xl overflow-hidden bg-white dark:bg-slate-900 border border-zinc-200 dark:border-slate-700">
-        {/* Scrollable içerik alanı */}
-        <div className="flex-1 min-h-0 overflow-y-auto">{children}</div>
+    <div className="flex min-h-0 flex-1 gap-4">
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-2xl border border-zinc-200 bg-white dark:border-slate-700 dark:bg-slate-900">
+        <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
 
-        {/* Alt nav bar — sadece article altında */}
-        <div className="shrink-0 border-t border-zinc-200 dark:border-slate-700 px-4 py-3 flex items-center justify-between gap-4">
-          <div className="flex-1 flex justify-start">
+        <div className="flex items-center justify-between gap-4 border-t border-zinc-200 px-4 py-3 dark:border-slate-700">
+          <div className="flex flex-1 justify-start">
             {prevSection ? (
               <Link
                 href={routes.section(courseSlug, prevSection.id)}
-                className="inline-flex items-center gap-2 text-sm font-semibold text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
+                className="inline-flex items-center gap-2 text-sm font-semibold text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
               >
-                <ChevronLeft className="w-4 h-4" />
-                <span className="hidden sm:inline">Önceki:</span>
-                <span className="max-w-[200px] truncate hidden sm:inline">{prevSection.title}</span>
+                <ChevronLeft className="h-4 w-4" />
+                <span className="hidden sm:inline">\u00d6nceki:</span>
+                <span className="hidden max-w-[200px] truncate sm:inline">{prevSection.title}</span>
               </Link>
             ) : (
               <span />
             )}
           </div>
 
-          <div className="flex-1 flex justify-end">
+          <div className="flex flex-1 justify-end">
             {nextSection ? (
               <Link
                 href={routes.section(courseSlug, nextSection.id)}
-                className="inline-flex items-center gap-2 text-sm font-semibold text-zinc-600 hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100 transition-colors"
+                className="inline-flex items-center gap-2 text-sm font-semibold text-zinc-600 transition-colors hover:text-zinc-900 dark:text-zinc-400 dark:hover:text-zinc-100"
               >
                 <span className="hidden sm:inline">Sonraki:</span>
-                <span className="max-w-[200px] truncate hidden sm:inline">{nextSection.title}</span>
-                <ChevronRight className="w-4 h-4" />
+                <span className="hidden max-w-[200px] truncate sm:inline">{nextSection.title}</span>
+                <ChevronRight className="h-4 w-4" />
               </Link>
             ) : (
               <span />
@@ -121,12 +127,11 @@ export function SectionActions({
         </div>
       </div>
 
-      {/* Sağ kolon: sidebar (Tamamladım butonu altta) — yüklenirken skeleton */}
       {progressLoading ? (
-        <aside className="hidden lg:flex w-64 xl:w-72 shrink-0 flex-col rounded-2xl border border-zinc-200 dark:border-slate-700 bg-white dark:bg-slate-900 px-3 py-4 gap-2">
-          <Skeleton className="h-4 w-24 mb-2" />
-          {sections.map((s) => (
-            <Skeleton key={s.id} className="h-9 w-full rounded-xl" />
+        <aside className="hidden w-64 shrink-0 flex-col gap-2 rounded-2xl border border-zinc-200 bg-white px-3 py-4 dark:border-slate-700 dark:bg-slate-900 lg:flex xl:w-72">
+          <Skeleton className="mb-2 h-4 w-24" />
+          {sections.map((section) => (
+            <Skeleton key={section.id} className="h-9 w-full rounded-xl" />
           ))}
           <div className="mt-auto pt-4">
             <Skeleton className="h-10 w-full rounded-xl" />

--- a/frontend/src/hooks/courses/use-course-detail.ts
+++ b/frontend/src/hooks/courses/use-course-detail.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import { queryKeys } from "@/lib/query-keys";
+import type { CourseDetail } from "@/types";
+
+export function useCourseDetail(slug: string) {
+  return useQuery({
+    queryKey: queryKeys.courses.detail(slug),
+    queryFn: async () => {
+      const { data } = await api.get<CourseDetail>(`/courses/${slug}`);
+      return data;
+    },
+    enabled: Boolean(slug),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+}

--- a/frontend/src/hooks/courses/use-course-detail.ts
+++ b/frontend/src/hooks/courses/use-course-detail.ts
@@ -13,6 +13,6 @@ export function useCourseDetail(slug: string) {
       return data;
     },
     enabled: Boolean(slug),
-    staleTime: Number.POSITIVE_INFINITY,
+    staleTime: Infinity,
   });
 }

--- a/frontend/src/hooks/courses/use-section-progress.ts
+++ b/frontend/src/hooks/courses/use-section-progress.ts
@@ -10,13 +10,15 @@ import type { SectionProgressItem } from "@/types";
 // Her section'ın completed durumu ve genel progress_percent döner.
 // Backend hazır olana kadar 404/500 → boş array ile graceful fallback.
 // ---------------------------------------------------------------------------
-export function useSectionProgress(courseId: string) {
+export function useSectionProgress(courseId?: string) {
   return useQuery<SectionProgressItem[]>({
-    queryKey: queryKeys.progress.byCourse(courseId),
+    queryKey: queryKeys.progress.byCourse(courseId ?? ""),
     queryFn: async () => {
+      if (!courseId) return [];
       const { data } = await api.get<SectionProgressItem[]>(`/enrollments/${courseId}/progress`);
       return data;
     },
+    enabled: Boolean(courseId),
     retry: false,
     staleTime: 1000 * 60 * 5,
     placeholderData: [],
@@ -28,11 +30,14 @@ export function useSectionProgress(courseId: string) {
 // Section tamamlandığında progress_percent ve completed_at güncellenir.
 // Optimistic update: backend gelmeden önce UI anında tepki verir.
 // ---------------------------------------------------------------------------
-export function useMarkSectionComplete(courseId: string) {
+export function useMarkSectionComplete(courseId?: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async (sectionIdStr: string) => {
+      if (!courseId) {
+        throw new Error("Course ID is required to mark section complete.");
+      }
       const { data } = await api.post<SectionProgressItem>(
         `/progress/sections/${sectionIdStr}/complete`,
       );
@@ -40,6 +45,10 @@ export function useMarkSectionComplete(courseId: string) {
     },
 
     onMutate: async (sectionIdStr: string) => {
+      if (!courseId) {
+        return { previous: undefined };
+      }
+
       await queryClient.cancelQueries({
         queryKey: queryKeys.progress.byCourse(courseId),
       });
@@ -71,6 +80,8 @@ export function useMarkSectionComplete(courseId: string) {
     onError: () => {},
 
     onSettled: () => {
+      if (!courseId) return;
+
       queryClient.invalidateQueries({
         queryKey: queryKeys.progress.byCourse(courseId),
       });

--- a/frontend/src/lib/fetchCourses.ts
+++ b/frontend/src/lib/fetchCourses.ts
@@ -1,14 +1,13 @@
 import { Course, CourseDetail, CourseListResponse } from "@/types";
 
-// Server-side fetch — SSG build time ve server component'larda kullanılır.
-// BACKEND_INTERNAL_URL doğrudan çağrılır; browser proxy'si (/api) pass edilmez.
+// Server-side fetch for SSG build time and server components.
+// BACKEND_INTERNAL_URL is called directly; browser proxy (/api) is not used.
 const backendBase = () =>
   (process.env.BACKEND_INTERNAL_URL ?? "http://localhost:8000").replace(/\/$/, "");
 
 /**
- * Backend HTTP hataları için typed error.
- * Hata mesajının regex ile parse edilmesi yerine `instanceof` ile
- * status koduna güvenli erişim sağlar.
+ * Typed error for backend HTTP responses.
+ * Allows safe status access via `instanceof`.
  */
 export class BackendError extends Error {
   constructor(
@@ -22,15 +21,15 @@ export class BackendError extends Error {
 
 async function serverGet<T>(path: string): Promise<T> {
   const res = await fetch(`${backendBase()}/v1${path}`, {
-    next: { revalidate: 60 }, // 60sn ISR — statik içerik sık değişmez
+    next: { revalidate: false },
   });
   if (!res.ok) throw new BackendError(res.status, path);
   return res.json() as Promise<T>;
 }
 
 // GET /courses  (BE-14)
-// Backend { items, page, limit, total } döndürür — items çıkarılır.
-// is_published=false kurslar backend tarafından filtrelenir.
+// Backend returns { items, page, limit, total } and we unwrap items.
+// Courses with is_published=false are filtered on the backend.
 export async function getCourses(): Promise<Course[]> {
   try {
     const response = await serverGet<CourseListResponse>("/courses");
@@ -41,12 +40,12 @@ export async function getCourses(): Promise<Course[]> {
 }
 
 // GET /courses/{slug}  (BE-14)
-// Slug bulunamazsa backend 404 döner → null return edilir.
+// Backend returns 404 for missing slugs, so we return null.
 export async function getCourseBySlug(slug: string): Promise<CourseDetail | null> {
   try {
     return await serverGet<CourseDetail>(`/courses/${slug}`);
   } catch (err: unknown) {
-    // Build sırasında backend yoksa veya 404/5xx gelirse çökme, null dön.
+    // Keep build resilient when backend is down or returns 404/5xx.
     console.error("Build-time fetch failed for slug:", slug, err);
     return null;
   }

--- a/frontend/src/lib/query-keys.ts
+++ b/frontend/src/lib/query-keys.ts
@@ -1,4 +1,8 @@
 export const queryKeys = {
+  courses: {
+    all: ["courses"] as const,
+    detail: (slug: string) => [...queryKeys.courses.all, "detail", slug] as const,
+  },
   dashboard: {
     all: ["dashboard"] as const,
     overview: () => [...queryKeys.dashboard.all, "overview"] as const,


### PR DESCRIPTION
<details open>
<summary><strong>🇹🇷 Türkçe</strong></summary>
<br>

## 🎯 İlgili Görev (Task)

Task Ticket Number #233 

## 📝 Açıklama
Bu PR, section sayfalarında courseId çözümünü build-time’dan runtime’a taşıyor. Böylece section SSG build süreci backend erişimine bağımlı olmaktan çıkıyor. SectionActions artık courseId prop’u almak yerine client tarafında reusable useCourseDetail(slug) hook’u ile course bilgisini çekiyor ve courseId gelene kadar “Tamamladım” aksiyonunu disabled tutuyor.

Ayrıca kurs fetch tarafında revalidate: 60 kaldırılıp revalidate: false yapılarak ISR yerine pure SSG modeline geçiliyor. Sonuç olarak section sayfaları backend ayakta olmasa bile build alabiliyor, runtime’da gerekli olan courseId ise yalnızca ihtiyaç anında alınıyor.

## 🔧 Değişiklik Türü

- [x] ✨ Yeni özellik (`feat`)
- [ ] 🐛 Hata düzeltmesi (`fix`)
- [ ] 📖 Dokümantasyon (`docs`)
- [ ] 📚 Kurs içeriği (`content`)
- [x] ♻️ Refactoring (`refactor`)
- [ ] 🧪 Test (`test`)
- [ ] ⚙️ Yapılandırma / bağımlılık (`chore`)

## 🧪 Test

- [x] `docker compose up --build` ile lokal ortamda test edildi
- [ ] Backend testleri geçti (`pytest tests/`)
- [ ] Frontend testleri geçti (`npm test`)
- [ ] Manuel test senaryoları uygulandı (aşağıya açıklayın)

**Manuel test notları:**
<!-- Hangi akışları test ettiğinizi kısaca açıklayın -->

## ✅ Kontrol Listesi

- [x] İlgili "Task Numarası" yukarıya eklendi
- [ ] Commit mesajları `CONTRIBUTING.md` dosyasındaki Conventional Commits standardına uygun
- [ ] Kod formatlandı (`ruff format` / `npm run lint`)
- [ ] Yaptığım değişiklikler için dokümantasyon güncellendi (gerekiyorsa)
- [ ] Breaking change yok — varsa aşağıda açıklandı
- [ ] MDX içerik değişikliği varsa `id` alanı değiştirilmedi
- [ ] DB şema değişikliği varsa Alembic migration eklendi

## 💬 Gözden Geçirenler İçin Notlar

<!-- Özellikle dikkat edilmesini istediğiniz noktalar veya sorularınız -->

</details>

---

<details>
<summary><strong>🇬🇧 English</strong></summary>
<br>

## 🎯 Related Task

Task Ticket Number #233 

## 📝 Description
This PR moves courseId resolution for section pages from build time to runtime, so section SSG no longer depends on the backend being available during build. SectionActions now fetches course detail on the client via a reusable useCourseDetail(slug) hook and keeps the “Tamamladım” action disabled until courseId is available.

It also switches course fetching from ISR to pure SSG by changing revalidate from 60 to false. As a result, section pages build successfully without backend access, while runtime-only actions still get the courseId when needed.

## 🔧 Change Type

- [x] ✨ New feature (`feat`)
- [ ] 🐛 Bug fix (`fix`)
- [ ] 📖 Documentation (`docs`)
- [ ] 📚 Course content (`content`)
- [x] ♻️ Refactoring (`refactor`)
- [ ] 🧪 Tests (`test`)
- [ ] ⚙️ Configuration / dependency (`chore`)

## 🧪 Testing

- [x] Tested locally with `docker compose up --build`
- [ ] Backend tests passed (`pytest tests/`)
- [ ] Frontend tests passed (`npm test`)
- [ ] Manual test scenarios applied (describe below)

**Manual test notes:**
<!-- Briefly describe which flows you tested -->

## ✅ Checklist

- [x] Related "Task Number" is included above
- [ ] Commit messages follow the Conventional Commits standard in `CONTRIBUTING.md`
- [ ] Code formatted (`ruff format` / `npm run lint`)
- [ ] Documentation updated for my changes (if applicable)
- [ ] No breaking changes — if yes, explained below
- [ ] If MDX content was changed, the `id` field was not modified
- [ ] If DB schema changed, an Alembic migration was added

## 💬 Notes for Reviewers

<!-- Any points you'd like reviewers to focus on, or questions you have -->

</details>